### PR TITLE
Pass `first_length` in `connect`, implement further subpartitioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,35 @@
-## mirage-block-partition -- simple block device partitioning
+## mirage-block-partition -- naïve block device partitioning
 
-Stupidly simple block device partitioning.
-You give a size of the first partition and as result you get back two devices where the first device has the length you gave and starts from the start of the block device.
-The other device returned is the rest of the original block device.
+Mirage-block-partition lets you view a mirage block device as smaller partitions.
 
-This implementation doesn't care about partition tables and thus there's plenty of opportunity to split the block device at the wrong point.
 
-Interested in using it?
-Beware, the interface is almost certain to be changed.
+
+```OCaml
+module Make(B : Mirage_block.S)(Clock : Mirage_clock.PCLOCK) = struct
+
+  module Partitioned = Mirage_block_partition.Make(B)
+  module Tar = Tar_mirage.Make_KV_RO(Partitioned)
+  module Chamelon = Kv.Make(Partitioned)(Clock)
+
+  let start b =
+    let open Lwt.Syntax in
+    let* r =
+      let open Lwt_result.Syntax in
+      (* b1 is the first kilobyte, b2 is the next 4 MB,
+         and b3 is the remaining space *)
+      let* b1, rest = Partitioned.connect 1024 in
+      let+ b2, b3 = Partitioned.subpartition 0x400000
+      b1, b2, b3
+    in
+    match r with
+    | Error e ->
+      Lwt.fail_with (Fmt.str "partition error: %a" Partitioned.pp_error e)
+    | Ok (b1, b2, b3) ->
+      (* now use e.g. b1 as a tar KV store, b2 as a chamelon filesystem,
+         b3 as a raw block device... *)
+      let* tar = Tar.connect b1
+      and* chamelon = Chamelon.connect ~program_size:16 b2 in
+      ...
+
+end
+```

--- a/lib/mirage_block_partition.mli
+++ b/lib/mirage_block_partition.mli
@@ -1,9 +1,13 @@
-module type PARTITION_AT = sig
-  (* XXX: should this be in bytes? in sectors?? *)
-  val first_length : int64
-end
-
-module Make(B : Mirage_block.S)(_ : PARTITION_AT) : sig
+module Make(B : Mirage_block.S) : sig
   include Mirage_block.S
-  val connect : B.t -> (t * t, error) result Lwt.t
+
+  val connect : int64 -> B.t -> (t * t, error) result Lwt.t
+  (** [connect first_length b] returns two block device partitions of b with
+   * the first partition of length [first_length] bytes, and the second
+   * partition the remaining space. [first_length] must be aligned to the
+   * sector size. *)
+
+  val connect' : int64 -> t -> (t * t, error) result Lwt.t
+  (** [connect first_length b] further partitions a partition into two sub
+   * partitions. [first_length] must be aligned to the sector size. *)
 end

--- a/lib/mirage_block_partition.mli
+++ b/lib/mirage_block_partition.mli
@@ -8,6 +8,6 @@ module Make(B : Mirage_block.S) : sig
    * sector size. *)
 
   val subpartition : int64 -> t -> (t * t, error) result
-  (** [connect first_length b] further partitions a partition into two sub
+  (** [subpartition first_length b] further partitions a partition into two sub
    * partitions. [first_length] must be aligned to the sector size. *)
 end

--- a/lib/mirage_block_partition.mli
+++ b/lib/mirage_block_partition.mli
@@ -7,7 +7,7 @@ module Make(B : Mirage_block.S) : sig
    * partition the remaining space. [first_length] must be aligned to the
    * sector size. *)
 
-  val connect' : int64 -> t -> (t * t, error) result Lwt.t
+  val subpartition : int64 -> t -> (t * t, error) result
   (** [connect first_length b] further partitions a partition into two sub
    * partitions. [first_length] must be aligned to the sector size. *)
 end

--- a/test/test_mirage_block_partition.ml
+++ b/test/test_mirage_block_partition.ml
@@ -1,9 +1,7 @@
 open Lwt.Syntax
 
-module P = struct
-  let first_length = 512L
-end
-module Partitioned = Mirage_block_partition.Make(Mirage_block_mem)(P)
+let first_length = 512L
+module Partitioned = Mirage_block_partition.Make(Mirage_block_mem)
 
 let cstruct = Alcotest.testable Cstruct.hexdump_pp Cstruct.equal
 (* XXX: polymorphic compare :'( *)
@@ -12,7 +10,7 @@ let partitioned_write_error = Alcotest.testable Partitioned.pp_write_error (=)
 
 let setup f () =
   let* b = Mirage_block_mem.connect "test" in
-  let* r = Partitioned.connect b in
+  let* r = Partitioned.connect first_length b in
   let b1, b2 =
     match r with
     | Ok (b1, b2) -> b1, b2
@@ -53,7 +51,7 @@ let first_partition_size (b, b1, b2) =
   let+ info = Mirage_block_mem.get_info b
   and+ info1 = Partitioned.get_info b1
   and+ _info2 = Partitioned.get_info b2 in
-  Alcotest.(check int64 "sector_size" P.first_length
+  Alcotest.(check int64 "first_partition_size" first_length
               Int64.(mul info1.size_sectors (of_int info.sector_size)))
 
 let write_first (b, b1, b2) =


### PR DESCRIPTION
After some consideration the `PARTITION_AT` module type seems inflexible. Instead, we pass the size to partition at to `connect`.

Furthermore, implement `connect'` which takes a partition and further sub partitions it into two.