### PR TITLE
Get rid of the split semantics, use start & len

### DIFF
--- a/lib/mirage_block_partition.mli
+++ b/lib/mirage_block_partition.mli
@@ -1,19 +1,17 @@
 module Make(B : Mirage_block.S) : sig
-  include Mirage_block.S
+  include Mirage_block.S with
+    type error = [ Mirage_block.error | `Block of B.error | `Out_of_bounds ]
+    and type write_error = [ Mirage_block.write_error | `Block of B.write_error | `Out_of_bounds ]
 
-  val connect : int64 -> B.t -> (t * t) Lwt.t
-  (** [connect first_sectors b] returns two block device partitions of b with
-      the first partition of [first_sectors] sectors, and the second partition
-      the remaining space, if any.
-      @raises Invalid_argument if the partition point is outside the device.
-  *)
+  val connect : B.t -> t Lwt.t
+  (** [connect b] is the partition spanning the entire block device [b]. *)
 
-  val subpartition : int64 -> t -> (t * t)
-  (** [subpartition first_sectors b] further partitions a partition into two sub
-      partitions.
-      @raises Invalid_argument if the partition point is outside the partition,
-      or if the partition is disconnected.
-  *)
+  val subpartition : start:int64 -> len:int64 -> t -> (t, error) result
+  (** [subpartition ~start ~len t] is [Ok t'] where [t'] is the sub partition
+      of [t] starting at [start] relative to [t] with [len] sectors, or [Error
+      `Out_of_bounds] if subpartition is outside [t].
+
+      @raise Invalid_argument when [start] or [len] are negative *)
 
   val get_offset : t -> int64
   (** [get_offset b] is the sector offset of the partition relative to the

--- a/lib/mirage_block_partition_mbr.ml
+++ b/lib/mirage_block_partition_mbr.ml
@@ -2,64 +2,20 @@ module Make(B : Mirage_block.S) = struct
   module P = Mirage_block_partition.Make(B)
   include P
 
-  type section =
-    | Unused of int64
-    | Partition of Mbr.Partition.t * int64
-
-  let sections offset partitions =
-    List.fold_left
-      (fun r p ->
-         let ( let* ) = Result.bind in
-         let* offset, ps = r in
-         let sector_start = Mbr.Partition.sector_start p
-         and size_sectors = Mbr.Partition.size_sectors p in
-         let* () =
-           if sector_start < offset then
-             Error `Overlapping_partitions
-           else Ok ()
-         in
-         let p =
-           Partition (p, size_sectors)
-         in
-         let ps =
-           if sector_start > offset then
-             p :: Unused (Int64.sub offset sector_start) :: ps
-           else
-             p :: ps
-         in
-         Ok (Int64.add sector_start size_sectors, ps))
-      (Ok (offset, []))
-      partitions
-    |> Result.map snd
-    |> Result.map List.rev
-
-
   let subpartition b (mbr : Mbr.t) =
-    let partitions =
-      List.sort (fun p1 p2 ->
-          Int32.unsigned_compare
-            p1.Mbr.Partition.first_absolute_sector_lba
-            p2.Mbr.Partition.first_absolute_sector_lba)
-        mbr.partitions
-    in
-    match sections (P.get_offset b) partitions with
-    | Error _ as e -> e
-    | Ok partitioning ->
+    let ( let* ) = Result.bind in
+    let* partitions =
       List.fold_left
         (fun acc p ->
-           let ( let* ) = Result.bind in
-           let* rest, ps = acc in
-           match p with
-           | Unused length ->
-             let _, rest = P.subpartition length rest in
-             Ok (rest, ps)
-           | Partition (p, length) ->
-             let b, rest = P.subpartition length rest in
-             Ok (rest, (p, b) :: ps))
-        (Ok (b, []))
-        partitioning
-      |> Result.map snd
-      |> Result.map List.rev
+           let* acc = acc in
+           let start = Mbr.Partition.sector_start p in
+           let len = Mbr.Partition.size_sectors p in
+           let* p' = P.subpartition ~start ~len b in
+           Ok ((p, p') :: acc))
+        (Ok [])
+        mbr.partitions
+    in
+    Ok (List.rev partitions)
 
   let connect b =
     let open Lwt.Syntax in
@@ -68,9 +24,9 @@ module Make(B : Mirage_block.S) = struct
        software will not behave correctly if sector size != 512. *)
     if sector_size <> Mbr.sizeof then
       Printf.ksprintf invalid_arg "Bad sector size: %d" sector_size;
-    let* (mbr, rest) = P.connect 1L b in
+    let* b = P.connect b in
     let buf = Cstruct.create Mbr.sizeof in
-    let* r = P.read mbr 0L [buf] in
+    let* r = P.read b 0L [buf] in
     begin match r with
       | Error e -> Format.kasprintf failwith "MBR read error: %a" pp_error e
       | Ok () -> ()
@@ -78,6 +34,6 @@ module Make(B : Mirage_block.S) = struct
     match Mbr.unmarshal buf with
     | Error e -> Printf.ksprintf Lwt.fail_with "Bad MBR: %s" e
     | Ok mbr ->
-      Lwt.return (subpartition rest mbr)
+      Lwt.return (subpartition b mbr)
 end
 

--- a/lib/mirage_block_partition_mbr.mli
+++ b/lib/mirage_block_partition_mbr.mli
@@ -1,9 +1,9 @@
 module Make(B : Mirage_block.S) : sig
   include Mirage_block.S
-  val connect : B.t -> ((Mbr.Partition.t * t) list, [ `Overlapping_partitions ]) result Lwt.t
+  val connect : B.t -> ((Mbr.Partition.t * t) list, error) result Lwt.t
   (** [connect b] returns a pair of [Mbr.Partition.t] from the MBR and a
       corresponding device representing the partition. An error is returned if
-      any of the partitions overlap.
-      @raise Invalid_argument if the the sector size of [b] is not exactly 512 bytes or if any of the partitions are outsie the device.
+      any of the partitions are outside the device.
+      @raise Invalid_argument if the the sector size of [b] is not exactly 512 bytes.
       @raise Failure if reading the MBR fails or does not parse. *)
 end

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,10 @@
 (test
  (name test_mirage_block_partition)
  (package mirage-block-partition)
- (libraries mirage-block-partition mirage-block-combinators lwt lwt.unix alcotest alcotest-lwt))
+ (libraries
+  mirage-block-partition
+  mirage-block-combinators
+  lwt
+  lwt.unix
+  alcotest
+  alcotest-lwt))


### PR DESCRIPTION
While the split semantics can help you partition the disk without overlaps it's mostly annoying because you usually either have a pair of start and end (or last) sectors, or a start sector and a length.

There is a regression of sorts in mirage-block-partition-mbr as we no longer check for overlapping partitions or partitions that include the MBR itself. It could be added back, but I suspect there are not any users of this code. So maybe better to just remove it altogether?!